### PR TITLE
Replace depricated ugettext with gettext

### DIFF
--- a/djangocms_rawhtml/cms_plugins.py
+++ b/djangocms_rawhtml/cms_plugins.py
@@ -1,7 +1,7 @@
 from cms.plugin_base import CMSPluginBase
 from cms.plugin_pool import plugin_pool
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from djangocms_rawhtml.models import RawHTMLPluginData
 
 @plugin_pool.register_plugin


### PR DESCRIPTION
ugettext got removed in Django 4.0: https://docs.djangoproject.com/en/4.2/releases/4.0/#features-removed-in-4-0
The fix is pretty straight forward.
